### PR TITLE
Remove GitHub metrics images

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,6 @@
   <img alt="github stats" height="150px" src="https://github-readme-stats.vercel.app/api?username=toguri&count_private=true&show_icons=true&show_icons=true&theme=onedark" />
 </p>
 
-![Metrics](https://metrics.lecoq.io/toguri)  
-<!-- ![Metrics](https://github.com/toguri/toguri/blob/main/github-metrics.svg) -->
 
 [![trophy](https://github-profile-trophy.vercel.app/?username=toguri&theme=gruvbox)](https://github.com/ryo-ma/github-profile-trophy)
 [![](https://raw.githubusercontent.com/toguri/toguri/master/profile-summary-card-output/dracula/0-profile-details.svg)](https://github.com/vn7n24fzkq/github-profile-summary-cards)


### PR DESCRIPTION
## Summary
- delete metrics image references from README

## Testing
- `grep -n "Metrics" README.md`

------
https://chatgpt.com/codex/tasks/task_b_68438ffedda08323af990a2a739d5951