### PR TITLE
Remove Zenn and Qiita badges from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,23 +26,6 @@
   </a>
 </p>
 
-<p align="left">
-  <a href="https://zenn.dev/toguri">
-    <img height="20" src="https://zenn.badge.nikaera.com/s/toguri/likes" />
-  </a>
-  <a href="https://zenn.dev/toguri">
-    <img height="20" src="https://zenn.badge.nikaera.com/s/toguri/followers" />
-  </a>
-  <a href="https://zenn.dev/toguri">
-    <img height="20" src="https://zenn.badge.nikaera.com/s/toguri/articles" />
-  </a>
-  <a href="http://qiita.com/toguri">
-    <img height="20" src="https://qiita-badge.apiapi.app/s/toguri/followers.svg" />
-  </a>
-  <a href="http://qiita.com/toguri">
-    <img height="20" src="https://qiita-badge.apiapi.app/s/toguri/posts.svg" />
-  </a>
-</p>
 
 [![](https://activity-graph.herokuapp.com/graph?username=toguri&theme=github)](https://activity-graph.herokuapp.com/graph?username=toguri&theme=github)
 [![](https://github-readme-streak-stats.herokuapp.com/?user=toguri&theme=dark)](https://github-readme-streak-stats.herokuapp.com/?user=toguri&theme=dark)


### PR DESCRIPTION
## Summary
- remove the Zenn and Qiita badge section from README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_68439bbd320c832393db151f9bbea1b7